### PR TITLE
improve error handling

### DIFF
--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -123,7 +123,7 @@ class CiviCRMRequestError extends Error {
     } catch (e) {}
 
     return {
-      error_message: error || "CiviCRM request failed",
+      error_message: error,
     };
   }
 
@@ -132,7 +132,7 @@ class CiviCRMRequestError extends Error {
 
     const { error_message, ...detail } = this.parseError(error);
 
-    this.message = error_message;
+    this.message = error_message || "CiviCRM request failed";
     this.detail = detail;
   }
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -93,7 +93,7 @@ export async function request(
   return json.values;
 }
 
-function handleError(errorResponse: string | object) {
+function handleError(errorResponse: string | object): never {
   const error = new CiviCRMRequestError(errorResponse);
 
   if (this.debug) {

--- a/test/api3.test.ts
+++ b/test/api3.test.ts
@@ -176,7 +176,12 @@ describe("debug", () => {
     } catch {}
 
     expect(consoleSpy.group).toHaveBeenCalled();
-    expect(consoleSpy.error).toHaveBeenCalledWith("Internal Server Error");
+    expect(consoleSpy.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "CiviCRMRequestError",
+        message: "Internal Server Error",
+      }),
+    );
     expect(consoleSpy.groupEnd).toHaveBeenCalled();
   });
 });

--- a/test/api4.test.ts
+++ b/test/api4.test.ts
@@ -239,7 +239,12 @@ describe("debug", () => {
     } catch {}
 
     expect(consoleSpy.group).toHaveBeenCalled();
-    expect(consoleSpy.error).toHaveBeenCalledWith("Internal Server Error");
+    expect(consoleSpy.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "CiviCRMRequestError",
+        message: "Internal Server Error",
+      }),
+    );
     expect(consoleSpy.groupEnd).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Requests will now throw a `CiviCRMRequestError` with the message provided by the API, if any, and a `detail` property containing any other details provided by the API.